### PR TITLE
Set the project's package to 'Flysystem'.

### DIFF
--- a/flysystem_swift.info.yml
+++ b/flysystem_swift.info.yml
@@ -1,5 +1,6 @@
 name: Flysystem OpenStack Swift
 description: 'Provides a Swift plugin for Flysystem.'
+package: Flysystem
 type: module
 core: 8.x
 dependencies:


### PR DESCRIPTION
By setting the project's "package" value to "Flysystem" it will group with all of the other Flysystem modules on the site's modules admin page.